### PR TITLE
Update for firmware 1.2303.00.0033

### DIFF
--- a/main.py
+++ b/main.py
@@ -142,10 +142,7 @@ def record_stats(target, timeout, count, target_url, output):
          statistics['WAN'][0]['Service'][0]['EthernetDiscardPacketsSent']],
 
         ['cellular_stats_discard_packets_received',
-         statistics['WAN'][0]['Service'][0]['EthernetDiscardPacketsReceived']],
-
-        ['cellular_stats_multicast_packets_received',
-         statistics['WAN'][0]['Service'][0]['MulticastPacketsReceived']]
+         statistics['WAN'][0]['Service'][0]['EthernetDiscardPacketsReceived']]
     ]
 
     column_names = []


### PR DESCRIPTION
multicast packet count is no longer sent, assuming firmware upgrade

        {
          "WanName": "WAN",
          "Enable": 1,
          "EthernetBytesSent": 69462215931,
          "EthernetBytesReceived": 380792737045,
          "EthernetPacketsSent": 239527209,
          "EthernetPacketsReceived": 378351454,
          "EthernetErrorsSent": 0,
          "EthernetErrorsReceived": 0,
          "EthernetDiscardPacketsSent": 0,
          "EthernetDiscardPacketsReceived": 0
        }